### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.0.2 (2020/mm/dd)
+
+* Renamed PyPI package from Jinja-Recurse to jinjarecurse. Please install via "pip install jinjarecurse".
+* [#1](https://github.com/diginc/Jinja-Recurse/issues/1): Added unit tests.
+
+## 0.0.1 (2020/10/09)
+
+* Initial release.
+* [#2](https://github.com/diginc/Jinja-Recurse/issues/2): Added GitHub workflow to publish package.

--- a/Pipfile
+++ b/Pipfile
@@ -14,5 +14,5 @@ python_version = "3.8"
 
 [dev-packages]
 pipenv-setup = "*"
-jinja-recurse = {path = "."}
+jinjarecurse = {path = "."}
 pytest = "*"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # jinjarecurse CLI tool
 
-Jinja Recursive Templating for the CLI.  Recursively template one file or many folders of many files like a config management languages allow, without the whole config management language.  Useful if you're switching from managing an application from config management to just docker and need some simple templating logic.
+Jinja Recursive Templating for the CLI.  Recursively template one file or many
+folders of many files like a config management languages allow, without the
+whole config management language.  Useful if you're switching from managing an
+application from config management to just docker and need some simple
+templating logic.
 
 ## Example Usage
 
@@ -84,7 +88,9 @@ last
 
 ### Directory
 
-You can also template an entire directory e.g. `i_dir` at once. Note the output files in the output directory will maintain the filenames from the input directory:
+You can also template an entire directory e.g. `i_dir` at once. Note the
+output files in the output directory will maintain the filenames from the
+input directory:
 
 ```
 $ jinjarecurse -v example/vars.yaml -i example/i_dir -o example/o_dir
@@ -106,3 +112,8 @@ Then invoke pytest:
 ```
 $ pipenv run py.test -vvvs
 ```
+
+## Changelog
+
+Please see the [Releases](https://github.com/diginc/Jinja-Recurse/releases)
+and [CHANGELOG.md](https://github.com/diginc/Jinja-Recurse/blob/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # jinjarecurse CLI tool
+_________________
+![PyPI](https://img.shields.io/pypi/v/jinjarecurse?color=blue)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/diginc/jinja-recurse/Upload%20Python%20Package)
+![GitHub](https://img.shields.io/github/license/diginc/jinja-recurse)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/jinjarecurse)
+_________________
 
 Jinja Recursive Templating for the CLI.  Recursively template one file or many
 folders of many files like a config management languages allow, without the
 whole config management language.  Useful if you're switching from managing an
 application from config management to just docker and need some simple
 templating logic.
+
+## Installation
+
+```
+pip install jinjarecurse
+```
 
 ## Example Usage
 
@@ -94,9 +106,9 @@ input directory:
 
 ```
 $ jinjarecurse -v example/vars.yaml -i example/i_dir -o example/o_dir
-Writing from example/i_dir/i_file_2 to example/o_dir/i_file_2
 Writing from example/i_dir/i_file to example/o_dir/i_file
 Writing from example/i_dir/i_file_1 to example/o_dir/i_file_1
+Writing from example/i_dir/i_file_2 to example/o_dir/i_file_2
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -1,17 +1,93 @@
-# Jinja Recurse CLI tool
+# jinjarecurse CLI tool
 
 Jinja Recursive Templating for the CLI.  Recursively template one file or many folders of many files like a config management languages allow, without the whole config management language.  Useful if you're switching from managing an application from config management to just docker and need some simple templating logic.
 
-## Example usage
+## Example Usage
 
 ```
-# Directory
-$ jinjarecurse -v example/vars.yaml -i example/i_dir -o example/o_dir
+$ jinjarecurse --help
+ jinjarecurse (CLI)
+
+Usage:
+    jinjarecurse --vars=VARS_FILE --input=INPUT_PATH --output=OUTPUT_PATH
+
+Options:
+    -v <file>, --vars   <file>
+    -i <file>, --input  <file>
+    -o <file>, --output <file>
+```
+
+### Single file
+
+Given a config file containing your variables e.g. `vars.yaml`:
+
+```
+#comment: not available
+root: /
+number: 1
+dictionary:
+    street: 123 North Ave
+    city: New York
+    state: New York
+list:
+    - ABC
+    - DEF
+    - HJK
+layer_1:
+    layer_2:
+        layer_3: last
+```
+
+And an input file jinja2 template e.g. `i_file`:
+
+```
+# Top level
+{{root}}
+{{number}}
+{{dictionary}}
+{{list}}
+{{layer_1}}
+
+# Nested data
+
+{{dictionary.street}}
+{{dictionary.city}}
+{{dictionary.state}}
+{{layer_1.layer_2.layer_3}}
+```
+
+You can populate it and specify an output filepath e.g. `o_file`:
+
+```
+$ jinjarecurse -v example/vars.yaml -i example/i_file -o example/o_file
 WARNING: example/o_file (output) exists and any conflicting files will be overwritten
 Writing from example/i_file to example/o_file
+```
 
-# Single File
-$ jinjarecurse -v example/vars.yaml -i example/i_file -o example/o_file
+Contents of the output file e.g. `o_file`:
+
+```
+# Top level
+/
+1
+{'street': '123 North Ave', 'city': 'New York', 'state': 'New York'}
+['ABC', 'DEF', 'HJK']
+{'layer_2': {'layer_3': 'last'}}
+
+# Nested data
+
+123 North Ave
+New York
+New York
+last
+```
+
+### Directory
+
+You can also template an entire directory e.g. `i_dir` at once. Note the output files in the output directory will maintain the filenames from the input directory:
+
+```
+$ jinjarecurse -v example/vars.yaml -i example/i_dir -o example/o_dir
 Writing from example/i_dir/i_file_2 to example/o_dir/i_file_2
 Writing from example/i_dir/i_file to example/o_dir/i_file
 Writing from example/i_dir/i_file_1 to example/o_dir/i_file_1
@@ -19,11 +95,14 @@ Writing from example/i_dir/i_file_1 to example/o_dir/i_file_1
 
 ## Tests
 
-To run the unit tests:
-```
-# First install the dependencies
-$ pipenv install --dev .
+To run the unit tests, first install the dependencies:
 
-# Then invoke pytest
+```
+$ pipenv install --dev .
+```
+
+Then invoke pytest:
+
+```
 $ pipenv run py.test -vvvs
 ```

--- a/jinjarecurse/main.py
+++ b/jinjarecurse/main.py
@@ -1,13 +1,12 @@
-""" Yet Another Jinja (YaJinja) (CLI)
+""" jinjarecurse (CLI)
 
 Usage:
-    yajinja [-m] --vars=VARS_FILE --input=INPUT_PATH --output=OUTPUT_PATH
+    jinjarecurse --vars=VARS_FILE --input=INPUT_PATH --output=OUTPUT_PATH
 
 Options:
     -v <file>, --vars   <file>
     -i <file>, --input  <file>
     -o <file>, --output <file>
-    -e <environment> ...
 """
 import jinja2
 import yaml
@@ -18,7 +17,7 @@ from docopt import docopt
 
 
 def main():
-    arguments = docopt(__doc__, version='YaJinja 0.1')
+    arguments = docopt(__doc__, version='jinjarecurse 0.0.2')
     paths = {
         'variables': Path(arguments['--vars']),
         'input': Path(arguments['--input']),
@@ -26,7 +25,6 @@ def main():
     }
     check_paths(**paths)
     variables = read_vars(paths['variables'])
-    #print(variables)
     template(paths, variables)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,15 @@ README = pathlib.Path(__file__).parent / "README.md"
 README = README.read_text()
 
 setup(
-    name="Jinja Recurse",
-    version="0.0.1",
+    name="jinjarecurse",
+    version="0.0.2",
     metadata_version="2.1",
     author="diginc",
     author_email="adam@diginc.us",
     description=("Jinja Recursive Templating from the CLI"),
     license="MIT",
     keywords="jinja templater",
-    url="https://www.github.com/diginc/jinjarecurse",
+    url="https://github.com/diginc/Jinja-Recurse",
     packages=["jinjarecurse"],
     long_description_content_type='text/markdown',
     long_description=README,
@@ -31,6 +31,6 @@ setup(
         "six==1.15.0",
     ],
     entry_points={
-        'console_scripts': [ 'jinjarecurse = jinjarecurse.main:main']
+        'console_scripts': ['jinjarecurse = jinjarecurse.main:main']
     }
 )


### PR DESCRIPTION
Hey @diginc,

I noticed in #2 you suggested the goal of `pip install jinjarecurse` but the `setup.py` still had the camelcase name "Jinja Recurse" which results in the PyPI package being uploaded as https://pypi.org/project/Jinja-Recurse/ (`pip install Jinja-Recurse`).

I've removed the references to the old name YaJinja as well so that everything except for the repo name is now simply "jinjarecurse".

Also added some minor things to the docs. The badges are configured for `jinjarecurse` so atm they can't find the package because it exists as `Jinja Recurse`, but once you do a release they will link up correctly and go green :+1: 

Cheers,
Kyle
